### PR TITLE
private to protected

### DIFF
--- a/src/Imapx.php
+++ b/src/Imapx.php
@@ -10,12 +10,12 @@ namespace Nahidz\Imapx;
 */
 class Imapx
 {
-    private $driver;
-    private $hostname;
-    private $username;
-    private $password;
-    private $ssl;
-    private $novalidate;
+    protected $driver;
+    protected $hostname;
+    protected $username;
+    protected $password;
+    protected $ssl;
+    protected $novalidate;
 
     protected $isConnect = false;
     protected $stream = '';

--- a/src/imapxPHP.php
+++ b/src/imapxPHP.php
@@ -8,13 +8,13 @@ class Imapx
     /*
         Here is all configurations that used in the library
     */
-    private $driver = 'imap';  // here is the driver. you can use pop3 also
-    private $hostname = 'imap.gmail.com'; // here is your host name,
-    private $username = 'name@gmail.com'; // your server username ex: john@gmail.com
-    private $password = 'your_pass';
-    private $port = 993;
-    private $ssl = true; // If you use false then the server ignore ssl
-    private $novalidate = false; // If novalidate true then your server use own validate certificate
+    protected $driver = 'imap';  // here is the driver. you can use pop3 also
+    protected $hostname = 'imap.gmail.com'; // here is your host name,
+    protected $username = 'name@gmail.com'; // your server username ex: john@gmail.com
+    protected $password = 'your_pass';
+    protected $port = 993;
+    protected $ssl = true; // If you use false then the server ignore ssl
+    protected $novalidate = false; // If novalidate true then your server use own validate certificate
     /*
         end configurations
     */


### PR DESCRIPTION
I have a problem to create dynamically configurated email-parser on Laravel (configurations from my DB, not from config file), so I tried to inherit your Imapx (add a constuctor with parameters), but private variables don't allowed to changing using inheritation.((( So I think would be better to change private to protected.
I don't know it is necessary for imapxPHP.php or not, but for Laravel version this fix will be good, I think.